### PR TITLE
Fixed exception when handling Cx settings without value in the response.

### DIFF
--- a/src/main/java/com/checkmarx/sonar/sensor/utils/CxConfigHelper.java
+++ b/src/main/java/com/checkmarx/sonar/sensor/utils/CxConfigHelper.java
@@ -159,7 +159,10 @@ public class CxConfigHelper {
     private String getPropertyValue(String responseJson) {
         String value = null;
         try {
-            value = responseJson.substring(responseJson.indexOf(VALUE) + 8, responseJson.length() - 4);
+            int valueIdx = responseJson.indexOf(VALUE);
+            if(valueIdx >= 0) {
+                value = responseJson.substring(valueIdx+8, responseJson.length() - 4);
+            }
         } catch (StringIndexOutOfBoundsException e) {
             log.debug("Fail to retrieve property value");
         }


### PR DESCRIPTION
When running from Gradle, as well as in some other cases, SonarQube would send an empty JSON string as Cx settings for a project.  The string has JSON format, but no value.  This would cause an exception thrown when processing projects without Checkmarx configuration:

```
com.checkmarx.sonar.cxportalservice.sast.exception.CxRestLoginException: Missing Checkmarx credentials
	at com.checkmarx.sonar.sensor.CheckmarxSensor.execute(CheckmarxSensor.java:73)
	at org.sonar.scanner.sensor.AbstractSensorWrapper.analyse(AbstractSensorWrapper.java:48)
	at org.sonar.scanner.sensor.ModuleSensorsExecutor.execute(ModuleSensorsExecutor.java:85)
	at org.sonar.scanner.sensor.ModuleSensorsExecutor.lambda$execute$1(ModuleSensorsExecutor.java:59)
```

instead of graceful handling of the error.  

The fix validates that the "value" actually exists in the returned string before processing it.