### PR TITLE
fix(security): update 3 vulnerable dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.10</version>
+            <version>3.18.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -254,7 +254,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.2</version>
+            <version>2.25.3</version>
             <scope>provided</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
@@ -356,7 +356,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-ext</artifactId>
-            <version>1.8.0-beta2</version>
+            <version>1.8.0-beta4</version>
         </dependency>
 		<dependency>
             <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
## Security Dependency Updates

This PR updates vulnerable dependencies identified by automated security scanning.

### Updated Packages

- slf4j-ext: 1.8.0-beta2 → 1.8.0-beta4 (fixes GHSA-w77p-8cfg-2x43)
- log4j-core: 2.17.2 → 2.25.3 (fixes GHSA-vc5p-v9hr-52mj)
- commons-lang3: 3.10 → 3.18.0 (fixes GHSA-j288-q9x7-2f5v)

### Files Modified

- C:\Users\AmolM\AppData\Local\Temp\deep_agent_scan_0y7ykz76\pom.xml

---
*Automated by Deep Agent*
